### PR TITLE
Moving images out of the domain class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /greenlight.iml
 /target/
 /web-app/bower_components/
+/web-app/attachments/

--- a/grails-app/controllers/uk/ac/ox/brc/greenlight/AttachmentController.groovy
+++ b/grails-app/controllers/uk/ac/ox/brc/greenlight/AttachmentController.groovy
@@ -25,7 +25,8 @@ class AttachmentController {
 	 * already migrated is fine.
 	 */
 	def migrateAll() {
-		respond attachmentService.migrateAllAttachments(), [formats:['xml', 'json']]
+		def results =  attachmentService.migrateAllAttachments()
+		respond results as Object, [formats:['xml', 'json']] as Map
 	}
 
     def list()

--- a/grails-app/controllers/uk/ac/ox/brc/greenlight/AttachmentController.groovy
+++ b/grails-app/controllers/uk/ac/ox/brc/greenlight/AttachmentController.groovy
@@ -5,6 +5,7 @@ import org.apache.pdfbox.pdmodel.PDDocument
 import org.apache.pdfbox.pdmodel.PDPage
 import org.apache.pdfbox.pdmodel.graphics.xobject.PDXObjectImage
 import org.apache.tomcat.jni.Shm
+import org.springframework.mock.web.MockMultipartFile
 import org.springframework.web.multipart.MultipartFile
 import org.springframework.web.multipart.MultipartHttpServletRequest
 
@@ -73,8 +74,7 @@ class AttachmentController {
     def showUploaded() {
     }
 
-    def save()
-    {
+    def save() {
         def attachments = []
         if(request instanceof MultipartHttpServletRequest) {
             MultipartHttpServletRequest multiRequest = (MultipartHttpServletRequest)request;
@@ -94,22 +94,14 @@ class AttachmentController {
 							ByteArrayOutputStream baos = new ByteArrayOutputStream()
 							ImageIO.write(page.convertToImage(BufferedImage.TYPE_INT_RGB, 256), "jpg", baos)
 
-							def attachment= new Attachment()
-							attachment.fileName = file?.originalFilename + "_page" + pageNumber
-							attachment.content = baos.toByteArray()
-							attachment.attachmentType=Attachment.AttachmentType.IMAGE
-							attachment.dateOfUpload=new Date()
-							attachmentService.save(attachment)
+							String singlePageName = file?.originalFilename + "_page" + pageNumber
+							MockMultipartFile singlePage = new MockMultipartFile(singlePageName, baos.bytes)
+							Attachment attachment = attachmentService.create(singlePage)
 							attachments.add(attachment)
 						}
 					}
 					else{
-						def attachment= new Attachment();
-						attachment.fileName = file?.originalFilename
-						attachment.content = file?.bytes
-						attachment.attachmentType=Attachment.AttachmentType.IMAGE
-						attachment.dateOfUpload=new Date()
-						attachmentService.save(attachment)
+						def attachment = attachmentService.create(file)
 						attachments.add(attachment)
 					}
 				}

--- a/grails-app/controllers/uk/ac/ox/brc/greenlight/AttachmentController.groovy
+++ b/grails-app/controllers/uk/ac/ox/brc/greenlight/AttachmentController.groovy
@@ -14,19 +14,24 @@ import java.awt.image.BufferedImage
 
 class AttachmentController {
 
-
     def attachmentService
+
+	def defaultAction = 'list'
+
+	/**
+	 * Trigger a migration of all attachments in the database.
+	 *
+	 * The operation is idempotent, so running many times or over items
+	 * already migrated is fine.
+	 */
+	def migrateAll() {
+		respond attachmentService.migrateAllAttachments(), [formats:['xml', 'json']]
+	}
 
     def list()
     {
         def result = attachmentService.getAllAttachments()
         respond result  , model:[attachments:result ]
-    }
-
-
-
-    def index() {
-        redirect action:'list'
     }
 
     def show(Attachment attachment) {

--- a/grails-app/domain/uk/ac/ox/brc/greenlight/Attachment.groovy
+++ b/grails-app/domain/uk/ac/ox/brc/greenlight/Attachment.groovy
@@ -2,16 +2,20 @@ package uk.ac.ox.brc.greenlight
 
 class Attachment {
 
-    byte[] content
+    byte[] content // deprecated. Use the fileUrl instead
+	String fileUrl // The location of the attachment file on disk. Replaces `content`
+
     Date dateOfUpload
     AttachmentType attachmentType
-    String fileName
+    String fileName // name of file as it was uploaded
 
     static belongsTo = [
             consentForm: ConsentForm
     ]
 
     static constraints = {
+		content nullable: true
+		fileUrl nullable: true // Just until we've migrated old attachments over. Remove in 2.0
         consentForm nullable: true
         content maxSize: 1024*1024*10
     }

--- a/grails-app/services/uk/ac/ox/brc/greenlight/AttachmentService.groovy
+++ b/grails-app/services/uk/ac/ox/brc/greenlight/AttachmentService.groovy
@@ -52,6 +52,19 @@ class  AttachmentService {
     }
 
 	/**
+	 * Migrate all attachments.
+	 * @return a map of the results (key: attachment.id, value: successBoolean)
+	 */
+	def migrateAllAttachments(){
+		def attachments = AttachmentService.findAll()
+		def results = [:]
+		attachments.each { attachment ->
+			results[attachment] = migrateAttachmentFromDatabase(attachment)
+		}
+		return results
+	}
+
+	/**
 	 * Move the contents of the Attachment from the database into the filesystem. If there is no content in the `content`
 	 * attribute then no action is taken and a successful response is given.
 	 *

--- a/grails-app/services/uk/ac/ox/brc/greenlight/AttachmentService.groovy
+++ b/grails-app/services/uk/ac/ox/brc/greenlight/AttachmentService.groovy
@@ -1,6 +1,7 @@
 package uk.ac.ox.brc.greenlight
 
 import grails.transaction.Transactional
+import org.springframework.mock.web.MockMultipartFile
 import org.springframework.web.multipart.MultipartFile
 
 @Transactional
@@ -28,9 +29,9 @@ class  AttachmentService {
 		attachment.save()
 
 		if (attachment.validate()) {
-			String filePath = fileUploadService.uploadFile(uploadedFile, attachment.id + ".jpg", 'attachments')
-			attachment.fileUrl = filePath
-			attachment.save()
+				String filePath = fileUploadService.uploadFile(uploadedFile, attachment.id + ".jpg", 'attachments')
+				attachment.fileUrl = filePath
+				attachment.save()
 		}
 		else {
 			log.error("Saving attachment failed: " + attachment.errors)
@@ -49,5 +50,47 @@ class  AttachmentService {
             content = attachment?.content;
         return content
     }
+
+	/**
+	 * Move the contents of the Attachment from the database into the filesystem. If there is no content in the `content`
+	 * attribute then no action is taken and a successful response is given.
+	 *
+	 * This is an idempotent operation.
+	 *
+	 * @param attachment The attachment to migrate the data within
+	 * @return true if the contents of the attachment are now in the filesystem, regardless of action taken
+	 */
+	boolean migrateAttachmentFromDatabase(Attachment attachment){
+		boolean success = true
+		// If the attachment is present and not empty
+		if (!(attachment.content == null || attachment.content.length == 0)) {
+
+			// Does the target file exist already?
+			File targetFile = "".asType(File)
+			if (targetFile.exists()){
+				log.error( "The target file ${targetFile} already exists. No action taken.")
+				success = false
+			}
+			else {
+				// Create the file from the byte array in the same way as we do for real uploads
+				MockMultipartFile uploadFile = new MockMultipartFile(attachment.id as String, attachment.content)
+				String filePath = fileUploadService.uploadFile(uploadFile, attachment.id + ".jpg", 'attachments')
+				attachment.fileUrl = filePath
+
+				// Verify that the new file's contents are identical
+				File externalFile = attachment.fileUrl as File
+				if (!externalFile.exists() || externalFile.bytes != attachment.content) {
+					log.error("Created external file contents do not match original byte array. Aborting.")
+					success = false
+				}else{
+					log.info("Content migrated successfully for attachment ${attachment.id}")
+					// Remove the old data and clean up
+					attachment.content = null
+					attachment.save()
+				}
+			}
+		}
+		return success
+	}
 }
 

--- a/grails-app/services/uk/ac/ox/brc/greenlight/AttachmentService.groovy
+++ b/grails-app/services/uk/ac/ox/brc/greenlight/AttachmentService.groovy
@@ -1,17 +1,42 @@
 package uk.ac.ox.brc.greenlight
 
 import grails.transaction.Transactional
+import org.springframework.web.multipart.MultipartFile
 
 @Transactional
-class AttachmentService {
+class  AttachmentService {
+
+	def fileUploadService
 
     def getAllAttachments() {
-      Attachment.list(sort: 'dateOfUpload', order: 'desc');
-
-        //Fixme try to use projection and
-        //do not load Content image files
-        //add a Boolean loadContent parameter to this method
+		Attachment.list(sort: 'dateOfUpload', order: 'desc');
     }
+
+	/**
+	 * Create a new attachment from a filename and byte array
+	 * @param uploadedFile The uploaded file
+	 * @return the created (and saved if possible) attachment object.
+	 */
+	Attachment create(MultipartFile uploadedFile){
+
+
+		Attachment attachment = new Attachment(
+				fileName: uploadedFile.name,
+				attachmentType: Attachment.AttachmentType.IMAGE,
+				dateOfUpload: new Date()
+		)
+		attachment.save()
+
+		if (attachment.validate()) {
+			String filePath = fileUploadService.uploadFile(uploadedFile, attachment.id + ".jpg", 'attachments')
+			attachment.fileUrl = filePath
+			attachment.save()
+		}
+		else {
+			log.error("Saving attachment failed: " + attachment.errors)
+		}
+
+	}
 
     def save(Attachment attachment) {
         attachment.save(flush: true);

--- a/grails-app/services/uk/ac/ox/brc/greenlight/AttachmentService.groovy
+++ b/grails-app/services/uk/ac/ox/brc/greenlight/AttachmentService.groovy
@@ -56,9 +56,9 @@ class  AttachmentService {
 	 * @return a map of the results (key: attachment.id, value: successBoolean)
 	 */
 	def migrateAllAttachments(){
-		def attachments = AttachmentService.findAll()
+		List<Attachment> attachments = Attachment.list()
 		def results = [:]
-		attachments.each { attachment ->
+		attachments.each { Attachment attachment ->
 			results[attachment] = migrateAttachmentFromDatabase(attachment)
 		}
 		return results

--- a/grails-app/services/uk/ac/ox/brc/greenlight/FileUploadService.groovy
+++ b/grails-app/services/uk/ac/ox/brc/greenlight/FileUploadService.groovy
@@ -1,0 +1,61 @@
+package uk.ac.ox.brc.greenlight
+
+import grails.transaction.Transactional
+import org.codehaus.groovy.grails.web.context.ServletContextHolder
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * A service to manage MultipartFile uploads
+ */
+@Transactional
+class FileUploadService {
+
+	def servletContext
+
+	// We want the whole upload to succeed or fail as a single transaction
+	boolean transactional = true
+
+	/**
+	 * Upload a file and store it on the server.
+	 *
+	 * Adapted from http://coderberry.me/blog/2010/10/12/uploading-files-in-grails/
+	 *
+	 * @param file The file contents
+	 * @param name The name to give the file on disk
+	 * @param destinationDirectory The (relative) directory to save to
+	 * @return The absolute path the to the file on disk. *THIS IS NOT THE ABSOLUTE URL FOR CLIENTS*
+	 */
+	def String uploadFile(MultipartFile file, String name, String destinationDirectory) {
+
+		// Do some sanity checking of the input
+		if (file == null || file.isEmpty()) {
+			log.error "File ${file} was null or empty!"
+			return null
+		}
+		else if (name == null || name.isEmpty()) {
+			log.error "The name of the file must not be null or the empty string"
+			return null
+		}
+		else if (destinationDirectory == null || destinationDirectory.isEmpty()) {
+			log.error "The name of the destinationDirectory must not be null or the empty string"
+			return null
+		}
+
+		def storagePath = servletContext.getRealPath(destinationDirectory)
+
+		// Create storage path directory if it does not exist
+		def storagePathDirectory = new File(storagePath)
+		if (!storagePathDirectory.exists()) {
+			log.info "CREATING DIRECTORY ${storagePath}: "
+			if (!storagePathDirectory.mkdirs()) {
+				log.error "FAILED to create directories for uploads: " + storagePath
+				return null
+			}
+		}
+
+		// Store file
+		file.transferTo(new File(storagePath + File.separator + name))
+		return storagePath + File.separator + name
+	}
+}
+

--- a/grails-app/views/attachment/show.gsp
+++ b/grails-app/views/attachment/show.gsp
@@ -10,17 +10,7 @@
     <div class="span12">
         <h1>Consent Form Detail</h1>
         <small>Date of Upload: <g:formatDate date="${attachment.dateOfUpload}" type="day"></g:formatDate></small>
-
-        <div class="row">
-            <div class="span12">
-            <g:if test="${attachment?.attachmentType == Attachment.AttachmentType.IMAGE}">
-                <img id="scannedForm" width="100%" class="Photo" src="${createLink(controller: 'attachment', action: 'viewContent', id: "${attachment.id}")}"/>
-            </g:if>
-            <g:elseif test="${attachment?.attachmentType == Attachment.AttachmentType.PDF}">
-                <g:render template="/attachment/pdfViewer" model="[attachmentId: attachment.id]"></g:render>
-            </g:elseif>
-            </div>
-        </div>
+        <img id="scannedForm" width="100%" class="Photo" src="${resource(dir:'attachments', file:attachment?.id + '.jpg')}"/>
     </div>
 </div>
 

--- a/grails-app/views/consentFormCompletion/_form.gsp
+++ b/grails-app/views/consentFormCompletion/_form.gsp
@@ -123,7 +123,7 @@
                 <g:if test="${commandInstance?.attachment}">
 
                     <a href="${createLink(action: 'show', controller: 'attachment', id: commandInstance?.attachment?.id)}" target="_blank">
-                    <img class="thumb" id="scannedForm"  src="${createLink(controller: 'attachment', action: 'viewContent', id: "${commandInstance?.attachment?.id}")}"/>
+                        <img id="scannedForm" style="margin: 4px; width: 100%;height: 100%" class="Photo" src="${resource(dir:'attachments', file: commandInstance?.attachment?.id + '.jpg')}" />
 
                     </a>
 

--- a/grails-app/views/consentFormCompletion/show.gsp
+++ b/grails-app/views/consentFormCompletion/show.gsp
@@ -115,8 +115,7 @@
 
                                         <g:if test="${commandInstance?.attachment?.attachmentType == Attachment.AttachmentType.IMAGE}">
 
-                                            <img id="scannedForm" style="margin: 4px; width: 100%;height: 100%" class="Photo"
-                                                 src="${createLink(controller: 'attachment', action: 'viewContent', id: "${commandInstance?.attachment?.id}")}"/>
+                                            <img id="scannedForm" style="margin: 4px; width: 100%;height: 100%" class="Photo" src="${resource(dir:'attachments', file: commandInstance?.attachment?.id + '.jpg')}" />
 
                                         </g:if>
                                         <g:elseif test="${commandInstance?.attachment?.attachmentType == Attachment.AttachmentType.PDF}">

--- a/test/integration/uk/ac/ox/brc/greenlight/AttachmentControllerISpec.groovy
+++ b/test/integration/uk/ac/ox/brc/greenlight/AttachmentControllerISpec.groovy
@@ -14,8 +14,8 @@ import spock.lang.Specification
  */
 //@TestFor(AttachmentController)
 //@Mock(Attachment)
-//class AttachmentControllerSpec extends Specification{
-class AttachmentControllerSpec extends IntegrationSpec {
+//class AttachmentControllerISpec extends Specification{
+class AttachmentControllerISpec extends IntegrationSpec {
 
     def attachmentController = new AttachmentController()
 
@@ -163,23 +163,7 @@ class AttachmentControllerSpec extends IntegrationSpec {
     }
 
 
-    def "Test if save rejects files other than Image and PDF"()
-    {
-        given:"A sample text file is uploaded"
-        def mockFile1 = new MockMultipartFile('scannedForms', 'input.txt','text/plain' , "TestMockContent" as byte[])
-        def mockFile2 = new MockMultipartFile('scannedForms', 'input.jpg','image/jpg' , "TestMockContent" as byte[])
-        def attCount = Attachment.count()
 
-        when:"uploading a text file"
-        attachmentController.metaClass.request = new MockMultipartHttpServletRequest();
-        attachmentController.request.addFile(mockFile1)
-        attachmentController.request.addFile(mockFile2)
-        attachmentController.save();
-
-        then:"the file should not be added"
-        Attachment.count() == attCount + 1
-        attachmentController.modelAndView.model.attachments.size()==1
-    }
 //    def "Test if Save, saves the uploaded file correctly"()
 //    {
 //        given:"A sample image file is uploaded"

--- a/test/unit/uk/ac/ox/brc/greenlight/AttachmentServiceSpec.groovy
+++ b/test/unit/uk/ac/ox/brc/greenlight/AttachmentServiceSpec.groovy
@@ -1,0 +1,68 @@
+package uk.ac.ox.brc.greenlight
+
+import grails.test.mixin.Mock
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+/**
+ * Created by rb on 24/04/2014.
+ */
+@Mock(Attachment)
+@TestFor(AttachmentService)
+class AttachmentServiceSpec extends Specification {
+
+	def "Migrate attachments into database"() {
+
+		given:
+		File inputFile = "resources" + File.separator + "ORBconsentform-empty.jpg" as File
+		Attachment attachment = new Attachment(
+				fileName: inputFile.name as String,
+				content: inputFile.bytes,
+				attachmentType: Attachment.AttachmentType.IMAGE,
+				dateOfUpload: new Date()
+			).save(failOnError: true)
+		String expectedFileLocation =  "target${File.separator}attachments${File.separator}${attachment.id}.jpg"
+		service.fileUploadService = Mock(FileUploadService)
+
+
+		when: "The migration is carried out"
+		boolean result = service.migrateAttachmentFromDatabase(attachment)
+		Attachment savedAttachment = Attachment.get(attachment.id)
+		then:
+		result == true
+		savedAttachment.content == null
+		savedAttachment.fileUrl == expectedFileLocation
+		(expectedFileLocation as File).exists()
+		(expectedFileLocation as File).bytes.length == inputFile.bytes.length
+		1 * service.fileUploadService.uploadFile(_, attachment.id + ".jpg", 'attachments') >> { _, filename, dir ->
+			// We need to mock the file copying bits. Ideally we should refactor the code under test to make this easier.
+			File path = expectedFileLocation as File
+			path.parentFile.mkdirs()
+			path.createNewFile()
+			path << inputFile.bytes
+		}
+
+		cleanup:
+		new File('attachments'+ File.separator + attachment.id + ".jpg").delete()
+		new File('attachments').delete()
+	}
+
+	def "Attempting migration from database when no data is present returns true but does nothing"() {
+
+		given:
+		Attachment attachment = new Attachment(
+				fileName: 'a.jpg',
+				attachmentType: Attachment.AttachmentType.IMAGE,
+				dateOfUpload: new Date()
+		).save(failOnError: true)
+
+		when: "The migration is carried out"
+		boolean result = service.migrateAttachmentFromDatabase(attachment)
+
+		then:
+		result == true
+		attachment.content == null
+	}
+
+	// TODO: Migration if the file exists fails
+}

--- a/test/unit/uk/ac/ox/brc/greenlight/FileUploadServiceSpec.groovy
+++ b/test/unit/uk/ac/ox/brc/greenlight/FileUploadServiceSpec.groovy
@@ -1,0 +1,64 @@
+package uk.ac.ox.brc.greenlight
+
+import grails.test.mixin.TestFor
+import org.springframework.mock.web.MockMultipartFile
+import org.springframework.web.multipart.MultipartFile
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.servlet.ServletContext
+
+@TestFor(FileUploadService)
+class FileUploadServiceSpec extends Specification {
+
+	@Unroll
+    void "Handling null parameters"(){
+
+		expect: "Null to be returned"
+		service.uploadFile(file as MultipartFile, name, destinationDirectory) == null
+
+		where:
+		file						| name 			| destinationDirectory
+		new MockMultipartFile("a")	| null			| null
+		new MockMultipartFile("a")	| null			| "dir"
+		new MockMultipartFile("a")	| "File.jpg"	| null
+		null						| "File.jpg"	| null
+		null						| "File.jpg"	| "dir"
+		null						| null			| "dir"
+		null						| null			| null
+	}
+
+	@Unroll
+	void "Handling empty parameters"(){
+
+		expect: "Null to be returned"
+		service.uploadFile(file as MultipartFile, name, destinationDirectory) == null
+
+		where:
+		file						| name 			| destinationDirectory
+		new MockMultipartFile("a")	| ""			| ""
+		new MockMultipartFile("a")	| ""			| "dir"
+		new MockMultipartFile("a")	| "File.jpg"	| ""
+		""							| "File.jpg"	| ""
+		""							| "File.jpg"	| "dir"
+		""							| ""			| "dir"
+		""							| ""			| ""
+	}
+
+	void "Uploading valid files"(){
+
+		given:
+		service.servletContext = Mock(ServletContext)
+
+		when:
+		String filePath = service.uploadFile(file, name, destinationDirectory)
+
+		then:
+		filePath == expectedPath
+		1 * service.servletContext.getRealPath(destinationDirectory) >> "/tmp/${destinationDirectory}"
+
+		where:
+		file										| name			| destinationDirectory 	| expectedPath
+		new MockMultipartFile('a', new byte[12])	| 'b'			| 'c'					| '/tmp/c/b'
+	}
+}


### PR DESCRIPTION
This change won't destroy old data, though it will need to be manually updated.

To migrate an installation use the `/attachment/migrateAll` URL. The results of the action are returned in XML format.
